### PR TITLE
[PT-510] Extend to be able to access identity properties for contacts

### DIFF
--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -143,11 +143,12 @@ module Hubspot
       end
     end
 
-    attr_reader :properties, :vid, :is_new
+    attr_reader :properties, :identity_profiles, :vid, :is_new
     attr_reader :is_contact
 
     def initialize(response_hash)
       props = response_hash['properties']
+      @identity_profiles = response_hash['identity-profiles']
       @properties = Hubspot::Utils.properties_to_hash(props) unless props.blank?
       @is_contact = response_hash["is-contact"]
       @vid = response_hash['vid']
@@ -167,6 +168,13 @@ module Hubspot
 
     def is_new=(val)
       @is_new = val
+    end
+
+    def emails
+      @identity_profiles
+        .flat_map { |profile| profile.fetch('identities', {}) }
+        .select { |identity| identity['type'] == 'EMAIL' }
+        .map { |identity| identity['value'] }
     end
 
     # Updates the properties of a contact

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -254,11 +254,13 @@ describe Hubspot::Contact do
         expect(first.vid).to eql 154835
         expect(first['firstname']).to eql 'HubSpot'
         expect(first['lastname']).to eql 'Test'
+        expect(first.emails).to eq %w[test@hubspot.com]
 
         expect(last).to be_a Hubspot::Contact
         expect(last.vid).to eql 196199
         expect(last['firstname']).to eql 'Eleanor'
         expect(last['lastname']).to eql 'Morgan'
+        expect(last.emails).to eq %w[emorgan@mdecorps.com]
       end
 
       it 'must get the contacts list with paging data' do


### PR DESCRIPTION
In an effort to improve our Hubspot contact syncing, we need to be able to view all email addresses associated to a contact in Hubspot.

Unfortunately, the gem we use is not maintained well and strips off most of the response Hubspot gives us using the raw API.

In an effort to minimize changes, I put together this PR to allow us to view the `identity_profiles` that come back from Hubspot without changing anything else right now.

This is the first step to improve the daily contact syncing we do. Once this is in place, we can re-write the sync to group user accounts in the same clusters as Hubspot does and only update each contact once/day.