### PR TITLE
[SWEET-965] feat: Add ability to use Hubspot Private App

### DIFF
--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -3,7 +3,7 @@ require 'logger'
 module Hubspot
   class Config
 
-    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger]
+    CONFIG_KEYS = [:hapikey, :bearer_token, :base_url, :portal_id, :logger]
     DEFAULT_LOGGER = Logger.new('/dev/null')
 
     class << self
@@ -12,6 +12,7 @@ module Hubspot
       def configure(config)
         config.stringify_keys!
         @hapikey = config["hapikey"]
+        @bearer_token = config["bearer_token"]
         @base_url = config["base_url"] || "https://api.hubapi.com"
         @portal_id = config["portal_id"]
         @logger = config['logger'] || DEFAULT_LOGGER
@@ -20,6 +21,7 @@ module Hubspot
 
       def reset!
         @hapikey = nil
+        @bearer_token = nil
         @base_url = "https://api.hubapi.com"
         @portal_id = nil
         @logger = DEFAULT_LOGGER


### PR DESCRIPTION
This makes the gem work for Hubspot's new Private Apps. Read all about it [here](https://developers.hubspot.com/docs/api/private-apps).

This fork is old, and so is the gem it was forked from. Neither are really maintained, but it makes more sense to tweak what we already have rather than refactor all the FW app Hubspot touchpoints for [Hubspot's ruby gem](https://github.com/HubSpot/hubspot-api-ruby).

This should be backward compatible with `hapikey` so merging ahead of FW app PR should work seamlessly with current Hubspot [initializer](https://github.com/getflywheel/flywheel-app/blob/main/config/initializers/hubspot.rb).