### PR TITLE
[SEN-1776] Adds sentry as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @getflywheel/sentry


### PR DESCRIPTION
Adds sentry as codeowners
https://wpengine.atlassian.net/browse/SEN-1776